### PR TITLE
setup-quickBuy-dawn

### DIFF
--- a/assets/gosub-product.js
+++ b/assets/gosub-product.js
@@ -1,0 +1,847 @@
+/* eslint-disable */
+var GoSubWidget = (function () {
+  function GoSubWidget() {
+    this.attrs = {
+      purchaseOptionOneTime: "data-gosub-purchase-option-one-time",
+      sellingPlanGroupId: "data-gosub-selling-plan-group-id",
+
+      sellingPlanIdInput: "data-gosub-selling-plan-id-input",
+
+      widget: "data-gosub-product",
+      sellingPlanOptionsContainer: "data-gosub-selling-plan-options-container",
+      sellingPlanOption: "data-gosub-selling-plan-option",
+      sellingPlansContainer: "data-gosub-selling-plans-container",
+      sellingPlanGroup: "data-gosub-selling-plan-group",
+      sellingPlanGroupInput: "data-gosub-selling-plan-group-input",
+      sellingPlan: "data-gosub-selling-plan",
+      sellingPlanInput: "data-gosub-selling-plan-input",
+      productJson: "data-gosub-product-json",
+      groupDiscountSummary: "data-gosub-group-discount-summary",
+      perDeliveryPrice: "data-gosub-per-delivery-price",
+      cartPopupDetails: "data-gosub-cart-popup-details",
+      cartPageDetails: "data-gosub-cart-page-details",
+      moneyFormat: "data-gosub-money-format",
+      pageTemplate: "data-gosub-page-template",
+    };
+
+    this.selectors = {
+      productForm: 'form[action*="/cart/add"]',
+      variantIdInput: '[name="id"]',
+      variantSelector: [
+        "#shappify-variant-id",
+        ".single-option-selector",
+        "select[name=id]",
+        "input[name=id]",
+      ],
+      sellingPlanGroupButton: ".gosub-widget__group",
+    };
+    // autogenerate selectors from attributes
+    Object.entries(this.attrs).forEach(
+      function ([key, value]) {
+        this.selectors[key] = `[${value}]`;
+      }.bind(this)
+    );
+
+    this.classes = {
+      hidden: "gosub__hidden",
+      selected: "gosub__plan-selected",
+    };
+
+    this.products = {};
+    this.variants = {};
+    this.sellingPlanGroups = {};
+    this.pageTemplate = "";
+  }
+
+  GoSubWidget.prototype = Object.assign({}, GoSubWidget.prototype, {
+    init: function () {
+      console.debug("GORIDE SUBSCRIPTION LOADING...");
+      if (!document.querySelector(this.selectors.widget)) {
+        console.debug("GORIDE SUB SKIPPED LOADING");
+        return;
+      }
+      this._parsePageTemplate();
+      this._parseProductJson();
+      this._addVariantChangeListener();
+
+      var widgets = document.querySelectorAll(this.selectors.widget);
+      widgets.forEach(
+        function (widget) {
+          this._renderPrices(widget);
+          // this._renderGroupDiscountSummary(widget)
+        }.bind(this)
+      );
+
+      window.addEventListener(
+        "pageshow",
+        function () {
+          this.syncAllVisuallySelected();
+        }.bind(this)
+      );
+
+      console.debug("GORIDE SUBSCRIPTION LOAD SUCCESSFUL");
+    },
+
+    /**
+     * Set the hidden selling_plan input to the visually selected plan in the widget.
+     * The browser caches form state between back and forward navigations, but doesn't emit change events.
+     */
+    syncAllVisuallySelected: function () {
+      var widgets = document.querySelectorAll(this.selectors.widget);
+      widgets.forEach(this._syncVisuallySelected.bind(this));
+    },
+
+    _syncVisuallySelected: function (widget) {
+      var selectedGroupEl = widget.querySelector(
+        `${this.selectors.sellingPlanGroupInput}:checked`
+      );
+      selectedGroupEl.dispatchEvent(new Event("change"));
+    },
+
+    _addVariantChangeListener: function () {
+      var selectors = document.querySelectorAll(
+        this.selectors.variantSelector.join()
+      );
+      selectors.forEach(
+        function (select) {
+          if (select) {
+            select.addEventListener(
+              "change",
+              function (event) {
+                var productForm = event.target.closest(
+                  this.selectors.productForm
+                );
+                if (!productForm) console.log("product form not found");
+                var widget = productForm?.querySelector(this.selectors.widget);
+
+                // NOTE: Variant change event needs to propagate to `input[name=id]`, so wait for that to happen...
+                setTimeout(
+                  function () {
+                    this._renderPrices(widget);
+                    // this._renderGroupDiscountSummary(widget)
+                  }.bind(this),
+                  100
+                );
+              }.bind(this)
+            );
+          }
+        }.bind(this)
+      );
+    },
+
+    _parsePageTemplate: function () {
+      var pageTemplateInputEl = document.querySelector(
+        this.selectors.pageTemplate
+      );
+      if (pageTemplateInputEl === null) {
+        return;
+      }
+      this.pageTemplate = pageTemplateInputEl.value;
+    },
+
+    _parseProductJson: function () {
+      var productJsonElements = document.querySelectorAll(
+        this.selectors.productJson
+      );
+
+      productJsonElements.forEach(
+        function (element) {
+          var productJson = JSON.parse(element.innerHTML);
+          this.products[element.dataset.gosubProductId] = productJson;
+
+          productJson.selling_plan_groups.forEach(
+            function (sellingPlanGroup) {
+              this.sellingPlanGroups[sellingPlanGroup.id] = sellingPlanGroup;
+            }.bind(this)
+          );
+
+          productJson.variants.forEach(
+            function (variant) {
+              this.variants[variant.id] = variant;
+            }.bind(this)
+          );
+        }.bind(this)
+      );
+    },
+
+    renderAllPrices: function () {
+      console.log("widgets renderAllPrices");
+      //console.log(widgets);
+      var widgets = document.querySelectorAll(this.selectors.widget);
+      widgets.forEach(this._renderPrices.bind(this));
+    },
+
+    /**
+     * Display "price / delivery" for each plan label.
+     * Should run again if variant changes.
+     */
+    _renderPrices: function (widget) {
+      // Check, product.selling_plan_groups.size > 1
+      const isMultiGroup = document
+        .querySelector("div.gosub-widget__wrapper")
+        .classList.contains("gosub-widget__wrapper--multi-group");
+      // console.log(`multigroup: ${isMultiGroup}`);
+      if (typeof widget === "undefined" || widget === null) {
+        widget = document.querySelector(this.selectors.widget);
+      }
+      var planRadioEls = widget.querySelectorAll(this.selectors.sellingPlan);
+      var variantId = this._getVariantId(widget);
+      if (variantId) {
+        planRadioEls.forEach(
+          function (element) {
+            var sellingPlanId = element.dataset.gosubSellingPlanId;
+            var sellingPlanAllocation = this._getSellingPlanAllocation(
+              variantId,
+              sellingPlanId
+            );
+            // console.log(variantId);
+            // console.log(sellingPlanId);
+            // console.log(sellingPlanAllocation);
+            // sets prices & hides the subscription option if it is not available for some variants.
+            var subscriptionOption = document.getElementsByClassName(
+              "gosub-widget__group"
+            )[1];
+            var subscriptionList = document.getElementsByClassName(
+              "gosub-widget__plans-container"
+            )[0];
+            var priceEl = element.querySelector(
+              this.selectors.perDeliveryPrice
+            );
+            if (sellingPlanAllocation != undefined) {
+              // varinatにsubscriptionが割り当てられているoption
+              if (isMultiGroup) {
+                element.classList.remove(this.classes.hidden);
+              } else {
+                if (subscriptionOption != undefined) {
+                  subscriptionOption.classList.remove(this.classes.hidden);
+                  subscriptionList.classList.remove(this.classes.hidden);
+                }
+              }
+              var price = sellingPlanAllocation.per_delivery_price;
+              var formattedPrice = this._formatPrice(price);
+              priceEl.innerHTML = formattedPrice;
+            } else {
+              // varinatにsubscriptionが割り当てられてないoption
+              if (isMultiGroup) {
+                element.classList.add(this.classes.hidden);
+              } else {
+                subscriptionOption.classList.add(this.classes.hidden);
+              }
+              //document.querySelectorAll("input[value=once]")[0]?.click();
+              subscriptionList.classList.add(this.classes.hidden);
+            }
+          }.bind(this)
+        );
+        if (isMultiGroup) {
+          const allOptions = document.querySelectorAll(
+            ".gosub-widget__plans-container"
+          );
+          const gosubBlock = document.querySelector("fieldset.gosub-product");
+          const subscriptionButton = document.querySelector(
+            ".gosub-widget__groups-container .gosub-widget__group:last-child"
+          );
+          gosubBlock.classList.remove("gosub__hidden");
+          subscriptionButton.classList.remove("gosub__hidden");
+          if (
+            document
+              .querySelector(".gosub-widget__groups-container")
+              .classList.contains("default-subscription-selected")
+          ) {
+            document.querySelectorAll("input[value=subscription]")[0]?.click();
+          }
+          for (const option of allOptions) {
+            option.classList.remove("gosub__hidden");
+          }
+          // if no active option in group, hide group.
+          const planGrups = document.querySelectorAll(
+            ".gosub-widget__plans-container.gosub-widget__plans-container__multiple"
+          );
+          for (const group of planGrups) {
+            const activeOption = group.querySelector(
+              ".gosub-widget__plan:not(.gosub__hidden)"
+            );
+            if (!activeOption) {
+              //console.log("active option is null");
+              group.classList.add("gosub__hidden");
+            }
+          }
+          const activeplanGrup = document.querySelector(
+            ".gosub-widget__plans-container.gosub-widget__plans-container__multiple:not(.gosub__hidden)"
+          );
+          if (!activeplanGrup) {
+            //console.log("subscription plan is null in this variant, so hide select buttons");
+            gosubBlock.classList.add("gosub__hidden");
+            subscriptionButton.classList.add("gosub__hidden");
+            document.querySelectorAll("input[value=once]")[0]?.click();
+          }
+          // set sellingPlan searchParms
+          const groupSelectedId =
+            document
+              .querySelector("input[data-gosub-selling-plan-input]:checked")
+              ?.closest(".gosub-widget__plans-container") ||
+            document.querySelector(".gosub-widget__plans-container");
+          const groupId = groupSelectedId.dataset.gosubSellingPlanGroupId;
+          const buyMethod = document.querySelector(
+            ".gosub-widget__group.gosub__plan-selected input"
+          ).value;
+          const sellingPlanId =
+            buyMethod === "once"
+              ? ""
+              : this._getActiveSellingPlanId(widget, groupId);
+          this._setSellingPlanIdInput(widget, sellingPlanId);
+        } else {
+          const gosubBlock = document.querySelector("fieldset.gosub-product");
+          const subscriptionButton = document.querySelector(
+            ".gosub-widget__groups-container .gosub-widget__group:last-child"
+          );
+          gosubBlock.classList.remove("gosub__hidden");
+          if (
+            document
+              .querySelector(".gosub-widget__groups-container")
+              .classList.contains("default-subscription-selected")
+          ) {
+            document.getElementById("inputSubscription")?.click();
+          }
+          if (subscriptionButton.classList.contains("gosub__hidden")) {
+            console.log(
+              "subscription plan is null in this variant, so hide select buttons"
+            );
+            gosubBlock.classList.add("gosub__hidden");
+            document.querySelectorAll("input[value=once]")[0]?.click();
+          }
+          // set sellingPlan searchParms
+          const groupId = document.querySelector(
+            ".gosub-widget__group.gosub__plan-selected input"
+          ).value;
+          const sellingPlanId =
+            groupId === "once"
+              ? ""
+              : this._getActiveSellingPlanId(widget, groupId);
+          this._setSellingPlanIdInput(widget, sellingPlanId);
+        }
+
+        // discount description change
+        const discountDescriptions = document.querySelectorAll(
+          ".gosub-discount-descriptions-container div"
+        );
+        discountDescriptions.forEach((description) => {
+          description.classList.add("gosub__hidden");
+        });
+        const currentPlansContainer = document
+          .querySelector(".gosub-widget__plan-label.active")
+          .closest(".gosub-widget__plans-container");
+        const currentWidget = document
+          .querySelector(".gosub-widget__plan-label.active")
+          .closest(".gosub-widget__plan");
+        // console.log(currentPlansContainer);
+        // console.log(currentWidget);
+        const currentCycle = currentWidget.dataset.gosubSellingPlanCycle;
+        const currentName = currentWidget.dataset.gosubSellingPlanName;
+        const activeDiscountDescription = currentPlansContainer.querySelector(
+          `div[data-gosub-plan-cycle="${currentCycle}"][data-gosub-plan-name="${currentName}"]`
+        );
+        if (activeDiscountDescription) {
+          activeDiscountDescription.classList.remove("gosub__hidden");
+        }
+      }
+    },
+
+    handleSellingPlanGroupChange: function (event) {
+      var groupRadioEl = event.target;
+      var groupId = groupRadioEl.value;
+      var widget = groupRadioEl.closest(this.selectors.widget);
+
+      var plansGroupButtons = widget.querySelectorAll(
+        this.selectors.sellingPlanGroupButton
+      );
+      var plansContainers = widget.querySelectorAll(
+        this.selectors.sellingPlansContainer
+      );
+
+      plansGroupButtons.forEach(
+        function (plansGroupButton) {
+          if (
+            plansGroupButton.querySelector(this.selectors.sellingPlanGroupInput)
+              .checked
+          ) {
+            plansGroupButton.classList.add(this.classes.selected);
+          } else {
+            plansGroupButton.classList.remove(this.classes.selected);
+          }
+        }.bind(this)
+      );
+
+      plansContainers.forEach(
+        function (plansContainer) {
+          var plansContainerGroupId =
+            plansContainer.dataset.gosubSellingPlanGroupId;
+          //console.log(plansContainerGroupId);
+          if (plansContainerGroupId === groupId && groupRadioEl.checked) {
+            plansContainer.classList.remove(this.classes.hidden);
+          } else {
+            plansContainer.classList.add(this.classes.hidden);
+          }
+        }.bind(this)
+      );
+
+      // discount description change
+      const discountDescriptions = document.querySelectorAll(
+        ".gosub-discount-descriptions-container div"
+      );
+      discountDescriptions.forEach((description) => {
+        description.classList.add("gosub__hidden");
+      });
+      const currentPlansContainer = document
+        .querySelector(".gosub-widget__plan-label.active")
+        .closest(".gosub-widget__plans-container");
+      const currentWidget = document
+        .querySelector(".gosub-widget__plan-label.active")
+        .closest(".gosub-widget__plan");
+      const currentCycle = currentWidget.dataset.gosubSellingPlanCycle;
+      const currentName = currentWidget.dataset.gosubSellingPlanName;
+      const activeDiscountDescription = currentPlansContainer.querySelector(
+        `div[data-gosub-plan-cycle="${currentCycle}"][data-gosub-plan-name="${currentName}"]`
+      );
+      if (activeDiscountDescription) {
+        activeDiscountDescription.classList.remove("gosub__hidden");
+      }
+
+      if (groupId === "once") {
+        this._setSellingPlanIdInput(widget, "");
+        return;
+      }
+
+      // TODO: Implement setting for plan options vs. plan list
+      // var selectedOptions = this._getSellingPlanOptions(groupId);
+      // var sellingPlan = this._getSellingPlanFromOptions(groupId, selectedOptions);
+
+      var sellingPlanId = this._getActiveSellingPlanId(widget, groupId);
+      this._setSellingPlanIdInput(widget, sellingPlanId);
+    },
+
+    handleSellingPlanGroupChangeMultipleGroup: function (event) {
+      const groupSelectedId =
+        document
+          .querySelector("input[data-gosub-selling-plan-input]:checked")
+          ?.closest(".gosub-widget__plans-container") ||
+        document.querySelector(".gosub-widget__plans-container");
+      const groupId = groupSelectedId.dataset.gosubSellingPlanGroupId;
+      var groupRadioEl = event.target;
+      var buyMethod = groupRadioEl.value;
+      var widget = groupRadioEl.closest(this.selectors.widget);
+
+      var plansGroupButtons = widget.querySelectorAll(
+        this.selectors.sellingPlanGroupButton
+      );
+      const plansContainer = document.getElementById(
+        "gosub-widget__plans-container-wrapper"
+      );
+
+      plansGroupButtons.forEach(
+        function (plansGroupButton) {
+          if (
+            plansGroupButton.querySelector(this.selectors.sellingPlanGroupInput)
+              .checked
+          ) {
+            plansGroupButton.classList.add(this.classes.selected);
+          } else {
+            plansGroupButton.classList.remove(this.classes.selected);
+          }
+        }.bind(this)
+      );
+
+      // discount description change
+      const discountDescriptions = document.querySelectorAll(
+        ".gosub-discount-descriptions-container div"
+      );
+      discountDescriptions.forEach((description) => {
+        description.classList.add("gosub__hidden");
+      });
+      const currentPlansContainer = document
+        .querySelector(".gosub-widget__plan-label.active")
+        .closest(".gosub-widget__plans-container");
+      const currentWidget = document
+        .querySelector(".gosub-widget__plan-label.active")
+        .closest(".gosub-widget__plan");
+      const currentCycle = currentWidget.dataset.gosubSellingPlanCycle;
+      const currentName = currentWidget.dataset.gosubSellingPlanName;
+      const activeDiscountDescription = currentPlansContainer.querySelector(
+        `div[data-gosub-plan-cycle="${currentCycle}"][data-gosub-plan-name="${currentName}"]`
+      );
+      if (activeDiscountDescription) {
+        activeDiscountDescription.classList.remove("gosub__hidden");
+      }
+
+      if (buyMethod === "subscription") {
+        plansContainer.classList.remove(this.classes.hidden);
+      } else {
+        plansContainer.classList.add(this.classes.hidden);
+      }
+
+      if (buyMethod === "once") {
+        this._setSellingPlanIdInput(widget, "");
+        return;
+      }
+
+      // TODO: Implement setting for plan options vs. plan list
+      // var selectedOptions = this._getSellingPlanOptions(groupId);
+      // var sellingPlan = this._getSellingPlanFromOptions(groupId, selectedOptions);
+
+      var sellingPlanId = this._getActiveSellingPlanId(widget, groupId);
+      this._setSellingPlanIdInput(widget, sellingPlanId);
+    },
+
+    handleSellingPlanChange: function (event) {
+      var planRadioEl = event.target;
+      var widget = planRadioEl.closest(this.selectors.widget);
+      this._setSellingPlanIdInput(widget, planRadioEl.value);
+      var labels = document.getElementsByClassName("gosub-widget__plan-label");
+      for (var i = 0; i < labels.length; i++) {
+        var btns = labels[i];
+        btns.classList.remove("active");
+      }
+      planRadioEl.parentNode.classList.add("active");
+
+      // discount description change
+      const discountDescriptions = document.querySelectorAll(
+        ".gosub-discount-descriptions-container div"
+      );
+      discountDescriptions.forEach((description) => {
+        description.classList.add("gosub__hidden");
+      });
+      const currentPlansContainer = planRadioEl.closest(
+        ".gosub-widget__plans-container"
+      );
+      const currentWidget = planRadioEl.closest(".gosub-widget__plan");
+      const currentCycle = currentWidget.dataset.gosubSellingPlanCycle;
+      const currentName = currentWidget.dataset.gosubSellingPlanName;
+      const activeDiscountDescription = currentPlansContainer.querySelector(
+        `div[data-gosub-plan-cycle="${currentCycle}"][data-gosub-plan-name="${currentName}"]`
+      );
+      if (activeDiscountDescription) {
+        activeDiscountDescription.classList.remove("gosub__hidden");
+      }
+    },
+
+    handleSellingPlanChangeMultipleGroup: function (event) {
+      var planRadioEl = event.target;
+      if (planRadioEl.checked === true) {
+        var widget = planRadioEl.closest(this.selectors.widget);
+        this._setSellingPlanIdInput(widget, planRadioEl.value);
+        var labels = document.getElementsByClassName(
+          "gosub-widget__plan-label"
+        );
+        for (var i = 0; i < labels.length; i++) {
+          var btns = labels[i];
+          btns.classList.remove("active");
+        }
+        planRadioEl.parentNode.classList.add("active");
+        // remove checked, if other radio is checked
+        const currentPlansContainer = planRadioEl.closest(
+          ".gosub-widget__plans-container.gosub-widget__plans-container__multiple"
+        );
+        const plansContainer = document.querySelectorAll(
+          ".gosub-widget__plans-container.gosub-widget__plans-container__multiple"
+        );
+        plansContainer.forEach((plan) => {
+          if (currentPlansContainer !== plan) {
+            const otherCheckedRadio = plan.querySelector("input:checked");
+            if (otherCheckedRadio) {
+              otherCheckedRadio.checked = false;
+            }
+          }
+        });
+
+        // discount description change
+        const discountDescriptions = document.querySelectorAll(
+          ".gosub-discount-descriptions-container div"
+        );
+        discountDescriptions.forEach((description) => {
+          description.classList.add("gosub__hidden");
+        });
+        const currentWidget = planRadioEl.closest(".gosub-widget__plan");
+        const currentCycle = currentWidget.dataset.gosubSellingPlanCycle;
+        const currentName = currentWidget.dataset.gosubSellingPlanName;
+        const activeDiscountDescription = currentPlansContainer.querySelector(
+          `div[data-gosub-plan-cycle="${currentCycle}"][data-gosub-plan-name="${currentName}"]`
+        );
+        if (activeDiscountDescription) {
+          activeDiscountDescription.classList.remove("gosub__hidden");
+        }
+      }
+    },
+
+    // NOTE: Selling Plan Options not supported in the current version of the widget...
+    handleSellingPlanOptionChange: function (event) {
+      var widget = event.target.closest(this.selectors.widget);
+
+      var sellingPlanGroupId = event.target.dataset.gosubSellingPlanGroupId;
+      var selectedOptions = this._getSellingPlanOptions(
+        widget,
+        sellingPlanGroupId
+      );
+      var sellingPlan = this._getSellingPlanFromOptions(
+        sellingPlanGroupId,
+        selectedOptions
+      );
+      this._setSellingPlanIdInput(sellingPlan.id);
+    },
+
+    _setSellingPlanIdInput: function (widget, sellingPlanId) {
+      // console.log(widget);
+      // console.log("sellingPlanId");
+      // console.log(sellingPlanId);
+      // create hidden input with selling plan inside product form. This input is what provides the weekly/monthly etc selling plan data to the cart
+      const targetForm = findClosestElement(
+        widget,
+        "form[action*='/cart/add']"
+      );
+      if (!targetForm) {
+        console.error(
+          "gosub: Could not find target form at setSellingPlanIdInput"
+        );
+      }
+      const sellingPlanIdInput = targetForm.querySelector(".SellingPlanInput");
+      if (!sellingPlanIdInput) {
+        console.log("there is no input yet");
+        var subscInput = document.createElement("input");
+        subscInput.type = "hidden";
+        subscInput.name = "selling_plan";
+        subscInput.value = sellingPlanId;
+        subscInput.classList.add("SellingPlanInput");
+        subscInput.setAttribute("data-gosub-selling-plan-id-input", "");
+        targetForm.prepend(subscInput);
+      } else {
+        //console.log("there is already an input");
+        sellingPlanIdInput.value = sellingPlanId;
+      }
+      var variantId = this._getVariantId(widget);
+
+      if (
+        /.*(product).*/.test(this.pageTemplate) ||
+        /.*(collections).*/.test(this.pageTemplate)
+      ) {
+        this._updateHistoryState(variantId, sellingPlanId);
+      }
+    },
+
+    _getSellingPlanGroup: function (groupId) {
+      if (!this.sellingPlanGroups[groupId]) {
+        console.error("gosub: Selling plan group data not found.");
+        return;
+      }
+
+      return this.sellingPlanGroups[groupId];
+    },
+
+    // NOTE: Selling Plan Options not supported in the current version of the widget...
+    _getSellingPlanOptions: function (widget, sellingPlanGroupId) {
+      var sellingPlanOptions = widget.querySelectorAll(
+        `${this.selectors.sellingPlanOption}[${this.attrs.sellingPlanGroupId}="${sellingPlanGroupId}"]:checked`
+      );
+
+      var selectedOptions = [];
+      sellingPlanOptions.forEach(function (optionElement) {
+        selectedOptions.push({
+          index: optionElement.dataset.gosubOptionIndex,
+          value: optionElement.value,
+        });
+      });
+
+      return selectedOptions;
+    },
+
+    // NOTE: Selling Plan Options not supported in the current version of the widget...
+    _getSellingPlanFromOptions: function (groupId, selectedOptions) {
+      var sellingPlans = this._getSellingPlanGroup(groupId).selling_plans;
+
+      var planFromOptions = sellingPlans.find(function (plan) {
+        return selectedOptions.every(function (option) {
+          return plan.options[option.index].value === option.value;
+        });
+      });
+
+      return planFromOptions;
+    },
+
+    _getVariantId: function (widget) {
+      var productForm = findClosestElement(widget, "form[action*='/cart/add']");
+      if (!productForm) {
+        console.error("gosub: Could not find product form at getVariantId.");
+      }
+
+      var variantIdInput = productForm.querySelector(
+        this.selectors.variantIdInput
+      );
+
+      return variantIdInput.value;
+    },
+
+    _getActiveSellingPlanId: function (widget, groupId) {
+      var activePlanInputEl = widget.querySelector(
+        `input[name=gosub-selling-plan-${groupId}]:checked`
+      );
+
+      if (!activePlanInputEl) {
+        console.error(
+          `gosub: Could not find active plan ID for group ${groupId}.`
+        );
+      }
+
+      return activePlanInputEl.value;
+    },
+
+    _updateHistoryState: function (variantId, sellingPlanId) {
+      if (!history.replaceState || !variantId) {
+        return;
+      }
+
+      var newurl =
+        window.location.protocol +
+        "//" +
+        window.location.host +
+        window.location.pathname +
+        "?";
+
+      if (sellingPlanId) {
+        newurl += "selling_plan=" + sellingPlanId + "&";
+      }
+
+      newurl += "variant=" + variantId;
+
+      window.history.replaceState({ path: newurl }, "", newurl);
+    },
+
+    /**
+     * SellingPlanAllocation is the the information of how a selling plan applies to a
+     * specific variant.
+     */
+    _getSellingPlanAllocation(variantId, sellingPlanId) {
+      var variant = this.variants[variantId];
+      if (!variant) {
+        console.error(`gosub: Could not find variant ID ${variantId}`);
+        return null;
+      }
+      return variant.selling_plan_allocations.find(function (plan) {
+        return `${plan.selling_plan_id}` === sellingPlanId;
+      });
+    },
+
+    _formatPrice(cents, format) {
+      var moneyElement = document.querySelector(this.selectors.moneyFormat);
+      var moneyFormat = moneyElement
+        ? moneyElement.getAttribute("data-gosub-money-format")
+        : null;
+
+      if (typeof cents === "string") {
+        cents = cents.replace(".", "");
+      }
+
+      var value = "";
+      var placeholderRegex = /\{\{\s*(\w+)\s*\}\}/;
+      var formatString =
+        format ||
+        moneyFormat ||
+        theme.moneyFormat ||
+        theme.strings.moneyFormat ||
+        Shopify.money_format ||
+        "$ {% raw %}{{ amount }}{% endraw %}";
+
+      function formatWithDelimiters(number, precision, thousands, decimal) {
+        thousands = thousands || ",";
+        decimal = decimal || ".";
+
+        if (isNaN(number) || number === null) {
+          return 0;
+        }
+
+        number = (number / 100.0).toFixed(precision);
+
+        var parts = number.split(".");
+        var dollarsAmount = parts[0].replace(
+          /(\d)(?=(\d\d\d)+(?!\d))/g,
+          "$1" + thousands
+        );
+        var centsAmount = parts[1] ? decimal + parts[1] : "";
+
+        return dollarsAmount + centsAmount;
+      }
+
+      switch (formatString.match(placeholderRegex)[1]) {
+        case "amount":
+          value = formatWithDelimiters(cents, 2);
+          break;
+        case "amount_no_decimals":
+          value = formatWithDelimiters(cents, 0);
+          break;
+        case "amount_with_comma_separator":
+          value = formatWithDelimiters(cents, 2, ".", ",");
+          break;
+        case "amount_no_decimals_with_comma_separator":
+          value = formatWithDelimiters(cents, 0, ".", ",");
+          break;
+        case "amount_no_decimals_with_space_separator":
+          value = formatWithDelimiters(cents, 0, " ");
+          break;
+        case "amount_with_apostrophe_separator":
+          value = formatWithDelimiters(cents, 2, "'");
+          break;
+      }
+
+      return formatString.replace(placeholderRegex, value);
+    },
+  });
+
+  return GoSubWidget;
+})();
+
+document.addEventListener("DOMContentLoaded", function () {
+  window.GORIDE = window.GORIDE || {};
+  window.GORIDE.GoSubWidget = new GoSubWidget();
+  window.GORIDE.GoSubWidget.init();
+});
+
+function findClosestElement(element, targetQuery) {
+  // まず、element自体とその祖先要素の中から探す
+  let closest = element.closest(targetQuery);
+  if (closest) return closest;
+
+  // 見つからなかった場合、documentのルートから探す
+  const allElements = document.querySelectorAll(targetQuery);
+  if (allElements.length === 0) return null;
+
+  // elementからの相対的な位置を計算して最も近い要素を見つける
+  let nearestElement = null;
+  let nearestDistance = 6;
+
+  allElements.forEach((targetElement) => {
+    // elementとtargetElementの位置関係を取得
+    const position = element.compareDocumentPosition(targetElement);
+
+    // 要素間の距離を計算（この方法は簡略化されています）
+    let distance;
+    if (position & Node.DOCUMENT_POSITION_CONTAINED_BY) {
+      // targetElementがelementの子孫の場合
+      distance = 0;
+    } else if (position & Node.DOCUMENT_POSITION_CONTAINS) {
+      // targetElementがelementの祖先の場合
+      distance = 1;
+    } else if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+      // targetElementがelementの後に来る場合
+      distance = 3;
+    } else if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+      // targetElementがelementの前に来る場合
+      distance = 4;
+    } else {
+      // その他の場合（最も遠い）
+      distance = 5;
+    }
+
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestElement = targetElement;
+    }
+  });
+
+  return nearestElement;
+}

--- a/assets/gosub.css
+++ b/assets/gosub.css
@@ -1,0 +1,2316 @@
+@charset "UTF-8";
+[data-address="root"] [data-aria-hidden="true"] {
+  display: none;
+}
+[data-address="root"] {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+[data-line-count="1"],
+[data-line-count="2"] {
+  flex-basis: 100%;
+}
+[data-line-count="3"] {
+  flex-basis: 32%;
+}
+._MRfuP {
+  overflow: hidden;
+}
+._bgndQ {
+  background-color: #000;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: none;
+  height: 100%;
+  left: 0;
+  overflow: auto;
+  padding-bottom: 50px;
+  padding-top: 100px;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 999;
+}
+._-rhRq {
+  background-color: #fff;
+  color: #333;
+  float: left;
+  left: 50%;
+  margin: auto;
+  max-height: 75%;
+  min-width: 500px;
+  overflow: auto;
+  padding: 20px;
+  position: absolute;
+  top: 50%;
+  border-radius: 8px;
+  transform: translate(-50%, -50%);
+}
+@media (max-width: 450px) {
+  ._-rhRq {
+    min-width: 350px;
+  }
+}
+@media (max-width: 350px) {
+  ._-rhRq {
+    min-width: 250px;
+  }
+}
+._9Orki {
+  color: inherit;
+  /* float: right; */
+  position: absolute;
+  top: 0;
+  right: 0.5em;
+  font-size: 28px;
+  font-weight: 700;
+}
+._9Orki:focus,
+._9Orki:hover {
+  opacity: 0.8;
+  cursor: pointer;
+  text-decoration: none;
+}
+.react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-year-read-view--down-arrow,
+.react-datepicker__navigation-icon:before,
+.react-datepicker__year-read-view--down-arrow {
+  border-color: #ccc;
+  border-style: solid;
+  border-width: 3px 3px 0 0;
+  content: "";
+  display: block;
+  height: 9px;
+  position: absolute;
+  top: 6px;
+  width: 9px;
+}
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle,
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle {
+  margin-left: -4px;
+  position: absolute;
+  width: 0;
+}
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle:after,
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle:before,
+.react-datepicker-popper[data-placement^="top"]
+  .react-datepicker__triangle:after,
+.react-datepicker-popper[data-placement^="top"]
+  .react-datepicker__triangle:before {
+  border: 8px solid transparent;
+  box-sizing: content-box;
+  content: "";
+  height: 0;
+  left: -8px;
+  position: absolute;
+  width: 1px;
+  z-index: -1;
+}
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle:before,
+.react-datepicker-popper[data-placement^="top"]
+  .react-datepicker__triangle:before {
+  border-bottom-color: #aeaeae;
+}
+.react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle {
+  margin-top: -8px;
+  top: 0;
+}
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle:after,
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle:before {
+  border-bottom-color: #f0f0f0;
+  border-top: none;
+}
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle:after {
+  top: 0;
+}
+.react-datepicker-popper[data-placement^="bottom"]
+  .react-datepicker__triangle:before {
+  border-bottom-color: #aeaeae;
+  top: -1px;
+}
+.react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle {
+  bottom: 0;
+  margin-bottom: -8px;
+}
+.react-datepicker-popper[data-placement^="top"]
+  .react-datepicker__triangle:after,
+.react-datepicker-popper[data-placement^="top"]
+  .react-datepicker__triangle:before {
+  border-bottom: none;
+  border-top-color: #fff;
+}
+.react-datepicker-popper[data-placement^="top"]
+  .react-datepicker__triangle:after {
+  bottom: 0;
+}
+.react-datepicker-popper[data-placement^="top"]
+  .react-datepicker__triangle:before {
+  border-top-color: #aeaeae;
+  bottom: -1px;
+}
+.react-datepicker-wrapper {
+  border: 0;
+  display: inline-block;
+  padding: 0;
+  width: 100%;
+}
+.react-datepicker {
+  background-color: #fff;
+  border: 1px solid #aeaeae;
+  border-radius: 0.3rem;
+  color: #000;
+  display: inline-block;
+  font-family: Helvetica Neue, helvetica, arial, sans-serif;
+  font-size: 0.8rem;
+  position: relative;
+}
+.react-datepicker--time-only .react-datepicker__triangle {
+  left: 35px;
+}
+.react-datepicker--time-only .react-datepicker__time-container {
+  border-left: 0;
+}
+.react-datepicker--time-only .react-datepicker__time,
+.react-datepicker--time-only .react-datepicker__time-box {
+  border-bottom-left-radius: 0.3rem;
+  border-bottom-right-radius: 0.3rem;
+}
+.react-datepicker__triangle {
+  left: 50px;
+  position: absolute;
+}
+.react-datepicker-popper {
+  z-index: 1;
+}
+.react-datepicker-popper[data-placement^="bottom"] {
+  padding-top: 10px;
+}
+.react-datepicker-popper[data-placement="bottom-end"]
+  .react-datepicker__triangle,
+.react-datepicker-popper[data-placement="top-end"] .react-datepicker__triangle {
+  left: auto;
+  right: 50px;
+}
+.react-datepicker-popper[data-placement^="top"] {
+  padding-bottom: 10px;
+}
+.react-datepicker-popper[data-placement^="right"] {
+  padding-left: 8px;
+}
+.react-datepicker-popper[data-placement^="right"] .react-datepicker__triangle {
+  left: auto;
+  right: 42px;
+}
+.react-datepicker-popper[data-placement^="left"] {
+  padding-right: 8px;
+}
+.react-datepicker-popper[data-placement^="left"] .react-datepicker__triangle {
+  left: 42px;
+  right: auto;
+}
+.react-datepicker__header {
+  background-color: #f0f0f0;
+  border-bottom: 1px solid #aeaeae;
+  border-top-left-radius: 0.3rem;
+  padding: 8px 0;
+  position: relative;
+  text-align: center;
+}
+.react-datepicker__header--time {
+  padding-bottom: 8px;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+.react-datepicker__header--time:not(.react-datepicker__header--time--only) {
+  border-top-left-radius: 0;
+}
+.react-datepicker__header:not(.react-datepicker__header--has-time-select) {
+  border-top-right-radius: 0.3rem;
+}
+.react-datepicker__month-dropdown-container--scroll,
+.react-datepicker__month-dropdown-container--select,
+.react-datepicker__month-year-dropdown-container--scroll,
+.react-datepicker__month-year-dropdown-container--select,
+.react-datepicker__year-dropdown-container--scroll,
+.react-datepicker__year-dropdown-container--select {
+  display: inline-block;
+  margin: 0 15px;
+}
+.react-datepicker-time__header,
+.react-datepicker-year-header,
+.react-datepicker__current-month {
+  color: #000;
+  font-size: 0.944rem;
+  font-weight: 700;
+  margin-top: 0;
+}
+.react-datepicker-time__header {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.react-datepicker__navigation {
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  height: 32px;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  text-align: center;
+  text-indent: -999em;
+  top: 2px;
+  width: 32px;
+  z-index: 1;
+}
+.react-datepicker__navigation--previous {
+  left: 2px;
+}
+.react-datepicker__navigation--next {
+  right: 2px;
+}
+.react-datepicker__navigation--next--with-time:not(
+    .react-datepicker__navigation--next--with-today-button
+  ) {
+  right: 85px;
+}
+.react-datepicker__navigation--years {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+  top: 0;
+}
+.react-datepicker__navigation--years-previous {
+  top: 4px;
+}
+.react-datepicker__navigation--years-upcoming {
+  top: -4px;
+}
+.react-datepicker__navigation:hover :before {
+  border-color: #a6a6a6;
+}
+.react-datepicker__navigation-icon {
+  font-size: 20px;
+  position: relative;
+  top: -1px;
+  width: 0;
+}
+.react-datepicker__navigation-icon--next {
+  left: -2px;
+}
+.react-datepicker__navigation-icon--next:before {
+  left: -7px;
+  transform: rotate(45deg);
+}
+.react-datepicker__navigation-icon--previous {
+  right: -2px;
+}
+.react-datepicker__navigation-icon--previous:before {
+  right: -7px;
+  transform: rotate(225deg);
+}
+.react-datepicker__month-container {
+  float: left;
+}
+.react-datepicker__year {
+  margin: 0.4rem;
+  text-align: center;
+}
+.react-datepicker__year-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 180px;
+}
+.react-datepicker__year .react-datepicker__year-text {
+  display: inline-block;
+  margin: 2px;
+  width: 4rem;
+}
+.react-datepicker__month {
+  margin: 0.4rem;
+  text-align: center;
+}
+.react-datepicker__month .react-datepicker__month-text,
+.react-datepicker__month .react-datepicker__quarter-text {
+  display: inline-block;
+  margin: 2px;
+  width: 4rem;
+}
+.react-datepicker__input-time-container {
+  clear: both;
+  float: left;
+  margin: 5px 0 10px 15px;
+  text-align: left;
+  width: 100%;
+}
+.react-datepicker__input-time-container .react-datepicker-time__caption,
+.react-datepicker__input-time-container
+  .react-datepicker-time__input-container {
+  display: inline-block;
+}
+.react-datepicker__input-time-container
+  .react-datepicker-time__input-container
+  .react-datepicker-time__input {
+  display: inline-block;
+  margin-left: 10px;
+}
+.react-datepicker__input-time-container
+  .react-datepicker-time__input-container
+  .react-datepicker-time__input
+  input {
+  width: auto;
+}
+.react-datepicker__input-time-container
+  .react-datepicker-time__input-container
+  .react-datepicker-time__input
+  input[type="time"]::-webkit-inner-spin-button,
+.react-datepicker__input-time-container
+  .react-datepicker-time__input-container
+  .react-datepicker-time__input
+  input[type="time"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.react-datepicker__input-time-container
+  .react-datepicker-time__input-container
+  .react-datepicker-time__input
+  input[type="time"] {
+  -moz-appearance: textfield;
+}
+.react-datepicker__input-time-container
+  .react-datepicker-time__input-container
+  .react-datepicker-time__delimiter {
+  display: inline-block;
+  margin-left: 5px;
+}
+.react-datepicker__time-container {
+  border-left: 1px solid #aeaeae;
+  float: right;
+  width: 85px;
+}
+.react-datepicker__time-container--with-today-button {
+  border: 1px solid #aeaeae;
+  border-radius: 0.3rem;
+  display: inline;
+  position: absolute;
+  right: -87px;
+  top: 0;
+}
+.react-datepicker__time-container .react-datepicker__time {
+  background: #fff;
+  border-bottom-right-radius: 0.3rem;
+  position: relative;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box {
+  border-bottom-right-radius: 0.3rem;
+  margin: 0 auto;
+  overflow-x: hidden;
+  text-align: center;
+  width: 85px;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list {
+  box-sizing: content-box;
+  height: calc(195px + 0.85rem);
+  list-style: none;
+  margin: 0;
+  overflow-y: scroll;
+  padding-left: 0;
+  padding-right: 0;
+  width: 100%;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item {
+  height: 30px;
+  padding: 5px 10px;
+  white-space: nowrap;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item:hover {
+  background-color: #f0f0f0;
+  cursor: pointer;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--selected {
+  background-color: #216ba5;
+  color: #fff;
+  font-weight: 700;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--selected:hover {
+  background-color: #216ba5;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--disabled {
+  color: #ccc;
+}
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--disabled:hover {
+  background-color: transparent;
+  cursor: default;
+}
+.react-datepicker__week-number {
+  color: #ccc;
+  display: inline-block;
+  line-height: 1.7rem;
+  margin: 0.166rem;
+  text-align: center;
+  width: 1.7rem;
+}
+.react-datepicker__week-number.react-datepicker__week-number--clickable {
+  cursor: pointer;
+}
+.react-datepicker__week-number.react-datepicker__week-number--clickable:hover {
+  background-color: #f0f0f0;
+  border-radius: 0.3rem;
+}
+.react-datepicker__day-names,
+.react-datepicker__week {
+  white-space: nowrap;
+}
+.react-datepicker__day-names {
+  margin-bottom: -8px;
+}
+.react-datepicker__day,
+.react-datepicker__day-name,
+.react-datepicker__time-name {
+  color: #000;
+  display: inline-block;
+  line-height: 1.7rem;
+  margin: 0.166rem;
+  text-align: center;
+  width: 1.7rem;
+}
+.react-datepicker__month--in-range,
+.react-datepicker__month--in-selecting-range,
+.react-datepicker__month--selected,
+.react-datepicker__quarter--in-range,
+.react-datepicker__quarter--in-selecting-range,
+.react-datepicker__quarter--selected {
+  background-color: #216ba5;
+  border-radius: 0.3rem;
+  color: #fff;
+}
+.react-datepicker__month--in-range:hover,
+.react-datepicker__month--in-selecting-range:hover,
+.react-datepicker__month--selected:hover,
+.react-datepicker__quarter--in-range:hover,
+.react-datepicker__quarter--in-selecting-range:hover,
+.react-datepicker__quarter--selected:hover {
+  background-color: #1d5d90;
+}
+.react-datepicker__month--disabled,
+.react-datepicker__quarter--disabled {
+  color: #ccc;
+  pointer-events: none;
+}
+.react-datepicker__month--disabled:hover,
+.react-datepicker__quarter--disabled:hover {
+  background-color: transparent;
+  cursor: default;
+}
+.react-datepicker__day,
+.react-datepicker__month-text,
+.react-datepicker__quarter-text,
+.react-datepicker__year-text {
+  cursor: pointer;
+}
+.react-datepicker__day:hover,
+.react-datepicker__month-text:hover,
+.react-datepicker__quarter-text:hover,
+.react-datepicker__year-text:hover {
+  background-color: #f0f0f0;
+  border-radius: 0.3rem;
+}
+.react-datepicker__day--today,
+.react-datepicker__month-text--today,
+.react-datepicker__quarter-text--today,
+.react-datepicker__year-text--today {
+  font-weight: 700;
+}
+.react-datepicker__day--highlighted,
+.react-datepicker__month-text--highlighted,
+.react-datepicker__quarter-text--highlighted,
+.react-datepicker__year-text--highlighted {
+  background-color: #3dcc4a;
+  border-radius: 0.3rem;
+  color: #fff;
+}
+.react-datepicker__day--highlighted:hover,
+.react-datepicker__month-text--highlighted:hover,
+.react-datepicker__quarter-text--highlighted:hover,
+.react-datepicker__year-text--highlighted:hover {
+  background-color: #32be3f;
+}
+.react-datepicker__day--highlighted-custom-1,
+.react-datepicker__month-text--highlighted-custom-1,
+.react-datepicker__quarter-text--highlighted-custom-1,
+.react-datepicker__year-text--highlighted-custom-1 {
+  color: #f0f;
+}
+.react-datepicker__day--highlighted-custom-2,
+.react-datepicker__month-text--highlighted-custom-2,
+.react-datepicker__quarter-text--highlighted-custom-2,
+.react-datepicker__year-text--highlighted-custom-2 {
+  color: green;
+}
+.react-datepicker__day--in-range,
+.react-datepicker__day--in-selecting-range,
+.react-datepicker__day--selected,
+.react-datepicker__month-text--in-range,
+.react-datepicker__month-text--in-selecting-range,
+.react-datepicker__month-text--selected,
+.react-datepicker__quarter-text--in-range,
+.react-datepicker__quarter-text--in-selecting-range,
+.react-datepicker__quarter-text--selected,
+.react-datepicker__year-text--in-range,
+.react-datepicker__year-text--in-selecting-range,
+.react-datepicker__year-text--selected {
+  background-color: #216ba5;
+  border-radius: 0.3rem;
+  color: #fff;
+}
+.react-datepicker__day--in-range:hover,
+.react-datepicker__day--in-selecting-range:hover,
+.react-datepicker__day--selected:hover,
+.react-datepicker__month-text--in-range:hover,
+.react-datepicker__month-text--in-selecting-range:hover,
+.react-datepicker__month-text--selected:hover,
+.react-datepicker__quarter-text--in-range:hover,
+.react-datepicker__quarter-text--in-selecting-range:hover,
+.react-datepicker__quarter-text--selected:hover,
+.react-datepicker__year-text--in-range:hover,
+.react-datepicker__year-text--in-selecting-range:hover,
+.react-datepicker__year-text--selected:hover {
+  background-color: #1d5d90;
+}
+.react-datepicker__day--keyboard-selected,
+.react-datepicker__month-text--keyboard-selected,
+.react-datepicker__quarter-text--keyboard-selected,
+.react-datepicker__year-text--keyboard-selected {
+  background-color: #bad9f1;
+  border-radius: 0.3rem;
+  color: #000;
+}
+.react-datepicker__day--keyboard-selected:hover,
+.react-datepicker__month-text--keyboard-selected:hover,
+.react-datepicker__quarter-text--keyboard-selected:hover,
+.react-datepicker__year-text--keyboard-selected:hover {
+  background-color: #1d5d90;
+}
+.react-datepicker__day--in-selecting-range:not(
+    .react-datepicker__day--in-range,
+    .react-datepicker__month-text--in-range,
+    .react-datepicker__quarter-text--in-range,
+    .react-datepicker__year-text--in-range
+  ),
+.react-datepicker__month-text--in-selecting-range:not(
+    .react-datepicker__day--in-range,
+    .react-datepicker__month-text--in-range,
+    .react-datepicker__quarter-text--in-range,
+    .react-datepicker__year-text--in-range
+  ),
+.react-datepicker__quarter-text--in-selecting-range:not(
+    .react-datepicker__day--in-range,
+    .react-datepicker__month-text--in-range,
+    .react-datepicker__quarter-text--in-range,
+    .react-datepicker__year-text--in-range
+  ),
+.react-datepicker__year-text--in-selecting-range:not(
+    .react-datepicker__day--in-range,
+    .react-datepicker__month-text--in-range,
+    .react-datepicker__quarter-text--in-range,
+    .react-datepicker__year-text--in-range
+  ) {
+  background-color: rgba(33, 107, 165, 0.5);
+}
+.react-datepicker__month--selecting-range
+  .react-datepicker__day--in-range:not(
+    .react-datepicker__day--in-selecting-range,
+    .react-datepicker__month-text--in-selecting-range,
+    .react-datepicker__quarter-text--in-selecting-range,
+    .react-datepicker__year-text--in-selecting-range
+  ),
+.react-datepicker__month--selecting-range
+  .react-datepicker__month-text--in-range:not(
+    .react-datepicker__day--in-selecting-range,
+    .react-datepicker__month-text--in-selecting-range,
+    .react-datepicker__quarter-text--in-selecting-range,
+    .react-datepicker__year-text--in-selecting-range
+  ),
+.react-datepicker__month--selecting-range
+  .react-datepicker__quarter-text--in-range:not(
+    .react-datepicker__day--in-selecting-range,
+    .react-datepicker__month-text--in-selecting-range,
+    .react-datepicker__quarter-text--in-selecting-range,
+    .react-datepicker__year-text--in-selecting-range
+  ),
+.react-datepicker__month--selecting-range
+  .react-datepicker__year-text--in-range:not(
+    .react-datepicker__day--in-selecting-range,
+    .react-datepicker__month-text--in-selecting-range,
+    .react-datepicker__quarter-text--in-selecting-range,
+    .react-datepicker__year-text--in-selecting-range
+  ) {
+  background-color: #f0f0f0;
+  color: #000;
+}
+.react-datepicker__day--disabled,
+.react-datepicker__month-text--disabled,
+.react-datepicker__quarter-text--disabled,
+.react-datepicker__year-text--disabled {
+  color: #ccc;
+  cursor: default;
+}
+.react-datepicker__day--disabled:hover,
+.react-datepicker__month-text--disabled:hover,
+.react-datepicker__quarter-text--disabled:hover,
+.react-datepicker__year-text--disabled:hover {
+  background-color: transparent;
+}
+.react-datepicker__month-text.react-datepicker__month--in-range:hover,
+.react-datepicker__month-text.react-datepicker__month--selected:hover,
+.react-datepicker__month-text.react-datepicker__quarter--in-range:hover,
+.react-datepicker__month-text.react-datepicker__quarter--selected:hover,
+.react-datepicker__quarter-text.react-datepicker__month--in-range:hover,
+.react-datepicker__quarter-text.react-datepicker__month--selected:hover,
+.react-datepicker__quarter-text.react-datepicker__quarter--in-range:hover,
+.react-datepicker__quarter-text.react-datepicker__quarter--selected:hover {
+  background-color: #216ba5;
+}
+.react-datepicker__month-text:hover,
+.react-datepicker__quarter-text:hover {
+  background-color: #f0f0f0;
+}
+.react-datepicker__input-container {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+}
+.react-datepicker__input-container .react-datepicker__calendar-icon {
+  padding: 0.5rem;
+  position: absolute;
+}
+.react-datepicker__view-calendar-icon input {
+  padding: 6px 10px 5px 25px;
+}
+.react-datepicker__month-read-view,
+.react-datepicker__month-year-read-view,
+.react-datepicker__year-read-view {
+  border: 1px solid transparent;
+  border-radius: 0.3rem;
+  position: relative;
+}
+.react-datepicker__month-read-view:hover,
+.react-datepicker__month-year-read-view:hover,
+.react-datepicker__year-read-view:hover {
+  cursor: pointer;
+}
+.react-datepicker__month-read-view:hover
+  .react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-read-view:hover
+  .react-datepicker__year-read-view--down-arrow,
+.react-datepicker__month-year-read-view:hover
+  .react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-year-read-view:hover
+  .react-datepicker__year-read-view--down-arrow,
+.react-datepicker__year-read-view:hover
+  .react-datepicker__month-read-view--down-arrow,
+.react-datepicker__year-read-view:hover
+  .react-datepicker__year-read-view--down-arrow {
+  border-top-color: #b3b3b3;
+}
+.react-datepicker__month-read-view--down-arrow,
+.react-datepicker__month-year-read-view--down-arrow,
+.react-datepicker__year-read-view--down-arrow {
+  right: -16px;
+  top: 0;
+  transform: rotate(135deg);
+}
+.react-datepicker__month-dropdown,
+.react-datepicker__month-year-dropdown,
+.react-datepicker__year-dropdown {
+  background-color: #f0f0f0;
+  border: 1px solid #aeaeae;
+  border-radius: 0.3rem;
+  left: 25%;
+  position: absolute;
+  text-align: center;
+  top: 30px;
+  width: 50%;
+  z-index: 1;
+}
+.react-datepicker__month-dropdown:hover,
+.react-datepicker__month-year-dropdown:hover,
+.react-datepicker__year-dropdown:hover {
+  cursor: pointer;
+}
+.react-datepicker__month-dropdown--scrollable,
+.react-datepicker__month-year-dropdown--scrollable,
+.react-datepicker__year-dropdown--scrollable {
+  height: 150px;
+  overflow-y: scroll;
+}
+.react-datepicker__month-option,
+.react-datepicker__month-year-option,
+.react-datepicker__year-option {
+  display: block;
+  line-height: 20px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+.react-datepicker__month-option:first-of-type,
+.react-datepicker__month-year-option:first-of-type,
+.react-datepicker__year-option:first-of-type {
+  border-top-left-radius: 0.3rem;
+  border-top-right-radius: 0.3rem;
+}
+.react-datepicker__month-option:last-of-type,
+.react-datepicker__month-year-option:last-of-type,
+.react-datepicker__year-option:last-of-type {
+  border-bottom-left-radius: 0.3rem;
+  border-bottom-right-radius: 0.3rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.react-datepicker__month-option:hover,
+.react-datepicker__month-year-option:hover,
+.react-datepicker__year-option:hover {
+  background-color: #ccc;
+}
+.react-datepicker__month-option:hover
+  .react-datepicker__navigation--years-upcoming,
+.react-datepicker__month-year-option:hover
+  .react-datepicker__navigation--years-upcoming,
+.react-datepicker__year-option:hover
+  .react-datepicker__navigation--years-upcoming {
+  border-bottom-color: #b3b3b3;
+}
+.react-datepicker__month-option:hover
+  .react-datepicker__navigation--years-previous,
+.react-datepicker__month-year-option:hover
+  .react-datepicker__navigation--years-previous,
+.react-datepicker__year-option:hover
+  .react-datepicker__navigation--years-previous {
+  border-top-color: #b3b3b3;
+}
+.react-datepicker__month-option--selected,
+.react-datepicker__month-year-option--selected,
+.react-datepicker__year-option--selected {
+  left: 15px;
+  position: absolute;
+}
+.react-datepicker__close-icon {
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  display: table-cell;
+  height: 100%;
+  outline: 0;
+  padding: 0 6px 0 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  vertical-align: middle;
+}
+.react-datepicker__close-icon:after {
+  background-color: #216ba5;
+  border-radius: 50%;
+  color: #fff;
+  content: "×";
+  cursor: pointer;
+  display: table-cell;
+  font-size: 12px;
+  height: 16px;
+  line-height: 1;
+  padding: 2px;
+  text-align: center;
+  vertical-align: middle;
+  width: 16px;
+}
+.react-datepicker__today-button {
+  background: #f0f0f0;
+  border-top: 1px solid #aeaeae;
+  clear: left;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 5px 0;
+  text-align: center;
+}
+.react-datepicker__portal {
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 2147483647;
+}
+.react-datepicker__portal .react-datepicker__day,
+.react-datepicker__portal .react-datepicker__day-name,
+.react-datepicker__portal .react-datepicker__time-name {
+  line-height: 3rem;
+  width: 3rem;
+}
+@media (max-height: 550px), (max-width: 400px) {
+  .react-datepicker__portal .react-datepicker__day,
+  .react-datepicker__portal .react-datepicker__day-name,
+  .react-datepicker__portal .react-datepicker__time-name {
+    line-height: 2rem;
+    width: 2rem;
+  }
+}
+.react-datepicker__portal .react-datepicker-time__header,
+.react-datepicker__portal .react-datepicker__current-month {
+  font-size: 1.44rem;
+}
+.react-datepicker__children-container {
+  height: auto;
+  margin: 0.4rem;
+  padding-left: 0.2rem;
+  padding-right: 0.2rem;
+  width: 13.8rem;
+}
+.react-datepicker__aria-live {
+  border: 0;
+  -webkit-clip-path: circle(0);
+  clip-path: circle(0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.react-datepicker__calendar-icon {
+  height: 1em;
+  vertical-align: -0.125em;
+  width: 1em;
+}
+@import "../../../shopify/theme/assets/gosub-product.css";
+.gosub-list .gosub-title {
+  border-bottom: 1px solid #ccc;
+  font-size: 24px;
+  font-weight: 700;
+}
+.gosub-list .gosub-container {
+  border: 1px solid #ccc;
+  margin-bottom: 24px;
+  overflow: auto;
+  padding: 30px;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container {
+    padding: 15px;
+  }
+}
+.gosub-list .gosub-container .gosub-cycle {
+  display: flex;
+  justify-content: space-between;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-cycle {
+    display: block;
+  }
+}
+.gosub-list .gosub-container .gosub-blackbtn {
+  background: #333;
+  border-radius: 50px;
+  color: #fff;
+  display: block;
+  height: 34px;
+  max-width: 316px;
+  width: 226px;
+}
+@media (max-width: 480px) {
+  .gosub-list .gosub-container .gosub-blackbtn {
+    margin: 0;
+    max-width: 226px;
+    width: 100%;
+  }
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-blackbtn {
+    margin: 0 auto;
+    width: 100%;
+  }
+}
+.gosub-list .gosub-container .gosub-blackbtn p {
+  padding: 9px 36px;
+}
+.gosub-list .gosub-container .gosub-togglebtn {
+  margin: 0 auto;
+  max-width: 200px;
+  width: 100%;
+}
+.gosub-list .gosub-container .gosub-rightbtn {
+  margin-top: 94px;
+}
+.gosub-list .gosub-container .gosub-rightbtn button {
+  margin-bottom: 20px;
+  margin-left: auto;
+  margin-top: 10px;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-rightbtn button {
+    margin-bottom: 30px;
+    margin-top: 30px;
+  }
+}
+.gosub-list .gosub-container .gosub-paymentMethod {
+  display: flex;
+  justify-content: space-between;
+  margin: 45px 0;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-paymentMethod {
+    display: block;
+  }
+}
+.gosub-list .gosub-container .gosub-paymentMethod .gosub-blackbtn {
+  margin-top: 45px;
+}
+@media (max-width: 480px) {
+  .gosub-list .gosub-container .gosub-paymentMethod .gosub-blackbtn {
+    margin: 0;
+  }
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-paymentMethod .gosub-blackbtn {
+    margin: 0 auto;
+    width: 100%;
+  }
+}
+.gosub-list .gosub-container .gosub-bold {
+  font-weight: 700;
+}
+.gosub-list .gosub-container .gosub-right {
+  text-align: right;
+}
+.gosub-list .gosub-container .gosub-product-info {
+  align-items: center;
+  display: flex;
+  gap: 20px;
+  padding: 5px 0;
+  width: 100%;
+}
+.gosub-list .gosub-container .gosub-product-info img {
+  border-radius: 4px;
+  border: 1px solid rgb(229 229 229);
+  height: 60px;
+  width: 60px;
+  object-fit: cover;
+  object-position: center;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-product-info img {
+    margin-right: 5px;
+  }
+}
+.gosub-list .gosub-container .gosub-product-info p {
+  margin: 0;
+}
+.gosub-list .gosub-container .gosub-product-info h2 {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 0;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-product-info h2 {
+    font-size: 14px;
+  }
+}
+.gosub-list .gosub-container .gosub-product-info .product-title {
+  align-items: center;
+  display: flex;
+}
+.gosub-list .gosub-container .gosub-product-info .product-qty {
+  font-size: 14px;
+  font-weight: 700;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-product-info .product-qty {
+    font-size: 12px;
+  }
+  .gosub-list .gosub-container .gosub-info {
+    display: block;
+  }
+}
+.gosub-list .gosub-container .gosub-info .gosub-billing {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin: 30px auto;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-info .gosub-billing {
+    display: block;
+  }
+}
+.gosub-list .gosub-container .gosub-info .gosub-delivery {
+  display: flex;
+  justify-content: space-between;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-info .gosub-delivery {
+    display: block;
+  }
+}
+.gosub-list .gosub-container .gosub-info .gosub-delivery .gosub-blackbtn {
+  margin-top: 45px;
+}
+@media (max-width: 480px) {
+  .gosub-list .gosub-container .gosub-info .gosub-delivery .gosub-blackbtn {
+    margin: 0;
+  }
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-info .gosub-delivery .gosub-blackbtn {
+    margin: 0 auto;
+    width: 100%;
+  }
+}
+.gosub-list .gosub-container .card-info {
+  display: flex;
+}
+.gosub-list .gosub-container .card-info .card-brand {
+  margin-right: 8px;
+  text-transform: capitalize;
+}
+.gosub-list .gosub-container .gosub-cancel {
+  display: flex;
+  justify-content: flex-end;
+  padding: 10px 0;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-cancel {
+    display: block;
+  }
+}
+.gosub-list .gosub-container .gosub-cancel .cancel-button {
+  cursor: pointer;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-cancel .cancel-button {
+    display: block;
+  }
+}
+.gosub-list .gosub-container .gosub-cancel .cancel-button:hover {
+  color: red;
+  opacity: 0.8;
+}
+.gosub-list .gosub-container .gosub-cancel .cancelled {
+  text-align: center;
+  width: 100px;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-container .gosub-cancel .cancelled {
+    display: block;
+  }
+}
+.gosub-list .gosub-redbtn {
+  color: red;
+  margin: 35px 0 0;
+  text-align: right;
+}
+@media (max-width: 768px) {
+  .gosub-list .gosub-redbtn {
+    margin: 30px 0 0;
+    text-align: center;
+  }
+}
+.gosub-list .isNotActive {
+  display: none;
+}
+.gosub-list .isActive {
+  display: block;
+}
+@keyframes gosub-fadeInFromNone {
+  0% {
+    display: none;
+    opacity: 0;
+  }
+  1% {
+    display: block;
+    opacity: 0;
+  }
+  to {
+    display: block;
+    opacity: 1;
+  }
+}
+.gosub-product legend {
+  font-weight: 700;
+}
+.gosub__hidden {
+  display: none;
+}
+.go-sub-status-badge-cancelled {
+  background: #b4b3b3;
+  padding: 2px 10px;
+}
+.go-sub-status-badge-paused {
+  background: #faee8f;
+  padding: 2px 10px;
+}
+.go-sub-status-badge-expired {
+  background: #ffc089;
+  padding: 2px 10px;
+}
+.go-sub-status-badge-failed {
+  background: #ff6b6b;
+  padding: 2px 10px;
+}
+.go-sub-status-badge-active {
+  background: #a7e5b9;
+  padding: 2px 10px;
+}
+.product-title {
+  gap: 12px;
+}
+.gosub-product-list {
+  max-height: 800px;
+  overflow: auto;
+}
+.gosub-product-container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  margin: 0;
+}
+.gosub-change-product button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  background: #333;
+  border: none;
+  border-radius: 50px;
+  color: #fff;
+  font-size: 10px;
+  height: 20px;
+}
+.gosub-buy-now-button,
+.gosub-change-cycle-button {
+  background: #333;
+  border: none;
+  border-radius: 50px;
+  color: #fff;
+  display: block;
+  font-size: 12px;
+  height: 30px;
+  width: 114px;
+}
+.gosub-contract-top {
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin: 20px 20px 0;
+}
+@media (max-width: 900px) {
+  .gosub-contract-top {
+    display: block;
+  }
+  .gosub-contract-num {
+    margin-top: 12px;
+  }
+}
+.gosub-contract-top-info {
+  flex-shrink: 0;
+  max-width: 700px;
+}
+.gosub-contract-top-start-date {
+  border-top: 1px solid #b5b5b5;
+}
+.gosub-min-max-cycles {
+  border-bottom: 1px solid #b5b5b5;
+  padding: 20px 30px;
+}
+.gosub-billing-cycle-show-less,
+.gosub-billing-details,
+.gosub-contract-top-next-date,
+.gosub-contract-top-start-date {
+  align-items: center;
+  border-bottom: 1px solid #b5b5b5;
+  display: flex;
+  gap: 24px;
+  padding: 20px 30px;
+}
+.gosub-billing-cycle-show-more {
+  align-items: center;
+  border-bottom: none;
+  display: flex;
+  gap: 24px;
+  padding: 20px 30px;
+}
+.gosub-contract-top-icon {
+  flex-shrink: 0;
+  font-weight: 700;
+  height: 20px;
+  width: 20px;
+}
+.gosub-contract-top-text {
+  display: flex;
+  flex-grow: 1;
+  gap: 16px;
+  justify-content: space-between;
+}
+.gosub-product-title h2 {
+  margin-top: 0 !important;
+}
+.gosub-billing-details {
+  flex-grow: 1;
+}
+.gosub-billing-details-item {
+  font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  line-height: 1.5;
+}
+
+.gosub-min-max-details,
+.gosub-cycle-frequency,
+.gosub-product-change-price,
+.gosub-order-history-details,
+.gosub-billing-details-item-subtext {
+  font-size: 12px;
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.gosub-billing-details-item-line {
+  border-bottom: 1px solid rgb(230, 230, 230) !important;
+  display: block !important;
+}
+.gosub-cycle-text {
+  gap: 8px;
+}
+.gosub-billing-cycle-description,
+.gosub-cycle-text,
+.gosub-next-date-description {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  justify-content: space-between;
+}
+.gosub-contract-bottom-info {
+  border-top: 1px solid #b5b5b5;
+  margin: 0 20px 20px;
+}
+.gosub-order-history-section,
+.gosub-delivery-address,
+.gosub-delivery-section,
+.gosub-payment-section,
+.gosub-cancel-date-section {
+  align-items: center;
+  border-bottom: 1px solid #b5b5b5;
+  display: flex;
+  gap: 24px;
+  padding: 20px 30px;
+}
+.gosub-delivery-address-text,
+.gosub-delivery-text,
+.gosub-payment-text {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  gap: 16px;
+  justify-content: space-between;
+}
+@media (max-width: 550px) {
+  .gosub-buy-button,
+  .gosub-contract-top-text,
+  .gosub-cycle-button,
+  .gosub-cycle-text,
+  .gosub-next-billing-text {
+    display: block !important;
+  }
+  .gosub-button-section {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .gosub-billing-cycle-right,
+  .gosub-next-billing-right {
+    align-items: flex-start !important;
+  }
+  .gosub-delivery-address-text,
+  .gosub-delivery-text,
+  .gosub-payment-text {
+    display: block;
+    flex-grow: 1;
+    gap: 16px;
+  }
+  .gosub-delivery-address-button,
+  .gosub-delivery-date-button,
+  .gosub-payment-button {
+    flex-shrink: 0;
+    margin-top: 8px;
+  }
+  .gosub-cancellation,
+  .gosub-pause,
+  .gosub-reactive,
+  .gosub-skip {
+    width: auto !important;
+  }
+}
+@media (max-width: 375px) {
+  .gosub-error-restart-button {
+    width: 100% !important;
+  }
+  .gosub-list .gosub-container .gosub-product-info img {
+    border-radius: 4px;
+    height: 40px;
+    width: 40px;
+  }
+  .gosub-product-info {
+    gap: 8px;
+  }
+  .gosub-min-max-cycles,
+  .gosub-order-history-section,
+  .gosub-billing-cycle-show-less,
+  .gosub-billing-cycle-show-more,
+  .gosub-billing-details,
+  .gosub-contract-top-next-date,
+  .gosub-contract-top-start-date,
+  .gosub-delivery-address,
+  .gosub-delivery-section,
+  .gosub-payment-section {
+    padding: 15px 0;
+  }
+  .gosub-contract-top-icon {
+    display: none;
+  }
+  .gosub-cancellation,
+  .gosub-pause,
+  .gosub-reactive,
+  .gosub-skip {
+    width: auto !important;
+  }
+}
+.gosub-delivery-address-button,
+.gosub-delivery-date-button,
+.gosub-payment-button {
+  background: #333;
+  border: none;
+  border-radius: 50px;
+  color: #fff;
+  display: block;
+  flex-shrink: 0;
+  font-size: 12px;
+  height: 30px;
+  width: 180px;
+}
+.gosub-buy-button,
+.gosub-cycle-button {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+.gosub-button-section,
+.gosub-show-more-button {
+  display: flex;
+  margin-top: 20px;
+}
+.gosub-button-section {
+  gap: 12px;
+  justify-content: center;
+}
+.gosub-next-billing-text {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  gap: 40px;
+  justify-content: space-between;
+}
+.gosub-cancellation,
+.gosub-pause,
+.gosub-reactive,
+.gosub-skip {
+  background: #333;
+  border: none;
+  border-radius: 50px;
+  color: #fff;
+  display: block;
+  font-size: 12px;
+  height: 32px;
+  width: 180px;
+}
+.gosub-pause:hover,
+.gosub-skip:hover,
+.gosub-reactive:hover {
+  opacity: 0.8;
+  cursor: pointer;
+  transition: 0.2s;
+}
+.gosub-cancellation:hover {
+  opacity: 0.8;
+  cursor: pointer;
+  transition: 0.2s;
+}
+.gosub-contract-num {
+  margin-bottom: 8px;
+}
+.gosub-buttons-icon {
+  font-weight: 700;
+  height: 20px;
+  width: 20px;
+}
+.gosub-buttons-inside {
+  display: flex;
+  gap: 8px;
+}
+.gosub-show-button {
+  background: none;
+  border: none;
+  color: gray;
+  text-align: center;
+}
+.gosub-show-button:hover {
+  opacity: 0.8;
+  cursor: pointer;
+  text-decoration: underline;
+  transition: 0.2s;
+}
+.gosub-quantity-button {
+  background: #333;
+  border: none;
+  border-radius: 50px;
+  color: #fff;
+  font-size: 10px;
+  margin-left: 8px;
+}
+.gosub-quantity-change button {
+  padding: 0 10px !important;
+}
+.gosub-buy-now-button:hover,
+.gosub-change-cycle-button:hover,
+.gosub-change-product-button:hover,
+.gosub-delivery-address-button:hover,
+.gosub-delivery-date-button:hover,
+.gosub-payment-button:hover,
+.gosub-quantity-button:hover {
+  opacity: 0.8;
+  cursor: pointer;
+  transition: 0.2s;
+}
+.gosub-active-disable,
+.gosub-all-disable,
+.gosub-cancelled-disable,
+.gosub-expired-disable,
+.gosub-failed-disable,
+.gosub-paused-disable {
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0.7;
+  cursor: pointer;
+  font-size: inherit;
+  padding-bottom: 3px;
+}
+/* .gosub-all-disable:hover,  */
+.gosub-all-contracts {
+  border: none;
+  border-bottom: 3px solid #389be7;
+}
+.gosub-active-contracts,
+.gosub-active-disable:hover,
+.gosub-all-contracts,
+.gosub-all-disable:hover {
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: 700;
+  padding-bottom: 3px;
+  transition: 0.2s;
+}
+
+/* .gosub-active-disable:hover, */
+.gosub-active-contracts {
+  border: none;
+  border-bottom: 3px solid #39d279;
+}
+/* .gosub-paused-disable:hover, */
+.gosub-paused-contracts {
+  border: none;
+  border-bottom: 3px solid #faee8f;
+}
+.gosub-expired-contracts,
+.gosub-expired-disable:hover,
+.gosub-paused-contracts,
+.gosub-paused-disable:hover {
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: 700;
+  padding-bottom: 3px;
+  transition: 0.2s;
+}
+/* .gosub-expired-disable:hover,  */
+.gosub-expired-contracts {
+  border: none;
+  border-bottom: 3px solid #ffc089;
+}
+/* .gosub-cancelled-disable:hover, */
+.gosub-cancelled-contracts {
+  border: none;
+  border-bottom: 3px solid #9c9c9c;
+}
+.gosub-cancelled-contracts,
+.gosub-cancelled-disable:hover,
+.gosub-failed-contracts,
+.gosub-failed-disable:hover {
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: 700;
+  padding-bottom: 3px;
+  transition: 0.2s;
+}
+/* .gosub-failed-disable:hover, */
+.gosub-failed-contracts {
+  border: none;
+  border-bottom: 3px solid #ff6b6b;
+}
+.gosub-filter {
+  border-left: 1px solid #b5b5b5;
+  border-radius: 5px 5px 0 0;
+  border-right: 1px solid #b5b5b5;
+  border-top: 1px solid #d4d4d4;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 15px 15px 10px;
+  width: 100%;
+}
+@media (max-width: 530px) {
+  .gosub-filter {
+    gap: 6px;
+    padding: 10px 5px 5px;
+  }
+  .gosub-failed-contracts,
+  /* .gosub-failed-disable:hover, */
+  .gosub-cancelled-contracts,
+  /* .gosub-cancelled-disable:hover, */
+  .gosub-expired-contracts,
+  /* .gosub-expired-disable:hover, */
+  .gosub-paused-contracts,
+  /* .gosub-paused-disable:hover, */
+  .gosub-active-contracts,
+  /* .gosub-active-disable:hover, */
+  /* .gosub-all-disable:hover,  */
+  .gosub-all-contracts {
+    font-size: 11px;
+  }
+  .gosub-active-disable,
+  .gosub-all-disable,
+  .gosub-cancelled-disable,
+  .gosub-expired-disable,
+  .gosub-failed-disable,
+  .gosub-paused-disable {
+    font-size: 11px;
+  }
+}
+.gosub-no-contracts {
+  border: 1px solid #b3b3b3;
+  border-radius: 0 0 5px 5px;
+  opacity: 0.7;
+  font-style: italic;
+  padding: 20px;
+  margin-bottom: 50px;
+}
+.gosub-billing-cycle-right,
+.gosub-next-billing-right {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+.modal-label {
+  display: flex;
+  gap: 8px;
+}
+.gosub-update-button {
+  background: #333;
+  border: none;
+  border-radius: 50px;
+  color: #fff;
+  display: block;
+  font-size: 12px;
+  height: 30px;
+  width: 114px;
+}
+.gosub-delete-button {
+  background: none;
+  color: #da4d4b;
+  border: none;
+  display: block;
+  font-size: 12px;
+}
+.gosub-update-button:hover {
+  opacity: 0.8;
+  cursor: pointer;
+  transition: 0.2s;
+}
+.gosub-delete-button:hover {
+  color: #b33634;
+  cursor: pointer;
+  transition: 0.2s;
+  font-style: underline;
+}
+.gosub-update-button:disabled {
+  background: #6d6d6d;
+  cursor: default;
+}
+
+.gosub__hidden {
+  display: none;
+}
+
+#gosub-account-root {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: 55px;
+  padding-right: 55px;
+}
+
+.gosub-product__purchase-options {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.gosub-product__purchase-options-group {
+  border: 1px lightgray solid;
+  border-bottom: none;
+  padding: 1em;
+  text-align: left;
+}
+
+.gosub-product__purchase-options-group__header {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.gosub-product__purchase-options-group__header-control {
+  flex-grow: 1;
+}
+
+.gosub-product__purchase-options-group__header-price-detail dl,
+.gosub-product__purchase-options-group__header-price-detail dd {
+  margin: 0;
+}
+.gosub-product__purchase-options-group__header-price-detail dd,
+.gosub-product__purchase-options-group__header-price-detail dt {
+  text-align: right;
+}
+.gosub-product__purchase-options-group__header-price-detail--fixture {
+  font-size: 0.7em;
+}
+
+.gosub-product__purchase-options-group:last-of-type {
+  border-bottom: 1px lightgray solid;
+}
+
+.gosub-product__purchase-options-group-option-list {
+  display: none;
+}
+.gosub-product__purchase-options-group--active
+  .gosub-product__purchase-options-group-option-list {
+  display: block;
+}
+.gosub-product__purchase-options-group--disabled
+  .gosub-product__purchase-options-group__header-price-detail {
+  display: none;
+}
+
+.gosub-product__purchase-options-group--disabled label {
+  cursor: auto;
+  color: #afafaf;
+}
+
+.gosub-product__purchase-options-group-option {
+  border: 0;
+  margin: 0 1em 1em 1.5em;
+}
+.gosub-product__purchase-options-group-option:last-of-type {
+  margin-bottom: 0;
+}
+
+.gosub-product__purchase-options-group-option__name {
+  margin-bottom: 0.2em;
+  padding: 0;
+}
+
+.gosub-product__purchase-options-group__control-group input[type="radio"] {
+  min-height: auto;
+  margin-right: 0.5em;
+}
+#gosub-account-root .gosub-list .gosub-container .gosub-blackbtn {
+  padding: 8px 20px;
+}
+._HyrdJ {
+  max-height: 95%;
+  overflow-y: auto;
+}
+._HyrdJ h2 {
+  font-size: 22px;
+  margin-bottom: 15px;
+}
+._HyrdJ h3 {
+  font-size: 18px;
+  margin-bottom: 15px;
+}
+._HyrdJ form .btn,
+._HyrdJ .btn {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  height: 35px;
+  align-items: center;
+  margin-top: 15px;
+}
+#GosubAccountModalContainer form input {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  border: 1px solid #6f6f6f;
+  border-radius: 2px;
+  padding: 4px 6px;
+}
+#GosubAccountModalContainer form input[type="radio"] {
+  width: auto;
+  margin-right: 8px;
+  margin-top: auto;
+  margin-bottom: auto;
+}
+#GosubAccountModalContainer form input[type="checkbox"] {
+  width: auto;
+  margin-right: 8px;
+  margin-top: auto;
+  margin-bottom: auto;
+}
+@media screen and (max-width: 767px) {
+  #gosub-account-root .gosub-list .gosub-container .gosub-blackbtn {
+    padding: 8px 0px;
+  }
+  #gosub-account-root {
+    padding: 0px;
+  }
+  #gosub-account-root .gosub-list .gosub-container .gosub-rightbtn {
+    display: block;
+  }
+}
+.product-area__media .slick-slide {
+  margin: 0 10px;
+}
+.product-area__media .slick-track {
+  margin: 0 -10px;
+}
+
+.gosub-product {
+  border: 0;
+  margin: 15px 0;
+  padding: 0;
+}
+.gosub-product legend {
+  font-weight: bold;
+}
+.gosub__hidden {
+  display: none;
+}
+.gosub-widget {
+  padding: 0 5px !important;
+  border: 0 !important;
+  margin: 0 !important;
+}
+.gosub-widget legend {
+  margin-bottom: 15px;
+}
+.gosub-widget__wrapper {
+  /* Hide the browser's default radio button */
+  /* Create a custom radio button */
+  /* On mouse-over, add a grey background color */
+  /* When the radio button is checked, add a blue background */
+  /* Create the indicator (the dot/circle - hidden when not checked) */
+  /* Show the indicator (dot/circle) when checked */
+  /* Style the indicator (dot/circle) */
+  max-width: 44rem;
+  margin: 0 auto;
+}
+.product--no-media .gosub-widget__wrapper {
+  max-width: 33rem;
+}
+.gosub-widget__wrapper fieldset {
+  background-color: inherit;
+  margin: 0;
+  padding: 0;
+}
+.gosub-widget__wrapper legend {
+  font-size: 14px;
+  width: 100%;
+  background: #333;
+  color: #fff;
+  padding: 5px 0 5px 10px;
+  font-weight: normal;
+}
+.gosub-widget__wrapper .gosub-widget__plan-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+  padding-left: 10px;
+  padding-right: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.gosub-widget__wrapper .gosub-widget__plan-label input {
+  accent-color: black;
+  transform: scale(1.5);
+}
+.gosub-widget__wrapper .gosub-checkmark {
+  height: 20px;
+  width: 20px;
+  background-color: #fff;
+  border: 2px solid #02abe3;
+  border-radius: 50%;
+}
+.gosub-widget__wrapper
+  .gosub-widget__plan-label:hover
+  input
+  ~ .gosub-checkmark {
+  background-color: #fff;
+  border: 2px solid #02abe3;
+}
+.gosub-widget__wrapper
+  .gosub-widget__group-label
+  input:checked
+  ~ .gosub-checkmark {
+  position: relative;
+  background-color: #fff;
+  border: 2px solid #02abe3;
+}
+.gosub-widget__wrapper .gosub-checkmark:after {
+  position: absolute;
+  content: "";
+  display: none;
+}
+.gosub-widget__wrapper .gosub-widget__group-label input {
+  display: none;
+}
+.product-detail__mall-list {
+  background: #ece5dd;
+  margin: 24px 0;
+  padding-top: 22px;
+  padding-bottom: 26px;
+}
+.product-detail__mall-list .mall-icon {
+  border-radius: 4px;
+  border: 1px solid #cccccc;
+  background-color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0px 6px;
+  width: 20px;
+  height: 50px;
+}
+.product-detail__mall-list .mall-icon a {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.product-detail__mall-list .mall-icon a img {
+  width: 90%;
+}
+.gosub-widget__wrapper
+  .gosub-widget__group-label
+  input:checked
+  ~ .gosub-checkmark:after {
+  display: block;
+}
+.gosub-widget__wrapper .gosub-widget__group-label .gosub-checkmark:after {
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #02abe3;
+}
+.product .item .info .gosub-widget__wrapper label.gosub-widget__group-label,
+.gosub-widget__wrapper label.gosub-widget__group-label {
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
+}
+.gosub-widget__wrapper label.gosub-widget__group-label {
+  display: flex;
+  align-items: baseline;
+}
+.gosub-widget__wrapper--single .gosub-widget__groups-container {
+  display: none;
+}
+.gosub-widget__wrapper .gosub-widget__group label {
+  background-color: #fff;
+  color: #333;
+  border: 2px solid #333;
+  padding: 10px;
+  display: flex;
+  align-items: center !important;
+}
+.gosub-widget__wrapper .gosub-widget__group label svg path {
+  fill: #333;
+}
+.gosub-widget__wrapper .gosub-widget__group.gosub__plan-selected label {
+  background-color: #333;
+  color: #fff;
+  display: flex;
+  align-items: center !important;
+}
+.gosub-widget__wrapper
+  .gosub-widget__group.gosub__plan-selected
+  label
+  svg
+  path {
+  fill: #fff;
+}
+.gosub-widget__wrapper .gosub-widget__group .gosub-widget__text {
+  display: flex;
+  align-items: center;
+  margin: 0;
+  gap: 15px;
+}
+.gosub-widget__group-header
+  .gosub-widget__text
+  .gosub-widget__wrapper--single
+  .gosub-widget__plans-container,
+.gosub-widget__wrapper--single .gosub-widget__options-container {
+  margin-top: 0;
+}
+.gosub-widget__description {
+  opacity: 0.7;
+  font-size: 12px;
+  font-style: italic;
+}
+.gosub-widget__groups-container {
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+}
+.gosub-widget__groups-container.default-subscription-selected {
+  flex-direction: row-reverse;
+}
+.gosub-widget__groups-container:only-child {
+  margin-bottom: 0;
+}
+.gosub-widget__group {
+  flex: 1 1 100%;
+}
+.gosub-widget__plans-container {
+  margin-top: 20px;
+}
+@media only screen and (min-width: 750px) and (max-width: 1130px) {
+  .gosub-widget__groups-container {
+    flex-direction: column;
+    gap: 0;
+  }
+  .gosub-widget__groups-container.default-subscription-selected {
+    flex-direction: column-reverse;
+  }
+  .gosub-widget__groups-container .go-sub-bottom-group {
+    margin-top: 10px;
+  }
+}
+@media (max-width: 338px) {
+  .gosub-widget__groups-container {
+    flex-direction: column;
+    gap: 0;
+  }
+  .gosub-widget__groups-container.default-subscription-selected {
+    flex-direction: column-reverse;
+  }
+  .gosub-widget__groups-container .go-sub-bottom-group {
+    margin-top: 10px;
+  }
+}
+@media only screen and (min-width: 768px) and (max-width: 1099px) {
+  .product-area__details__thumbs {
+    margin-top: 50px;
+  }
+}
+@media only screen and (max-width: 767px) {
+  .clickyboxes.options- li a,
+  .gosub-widget__plan-label {
+    font-size: 12px;
+  }
+  .gosub-widget__wrapper .gosub-widget__plan-label {
+    font-size: 12px;
+  }
+}
+.gosub-widget__group-header .gosub-widget__image {
+  display: block;
+  width: 4em;
+  height: 4em;
+}
+.gosub-widget__group-header .plan-svg {
+  visibility: hidden;
+  margin-left: auto;
+}
+input:checked + .gosub-widget__group-header .plan-svg {
+  visibility: visible;
+}
+.gosub-widget__group-label {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+.product .item .info .gosub-widget__wrapper label:after {
+  content: none;
+}
+.gosub-widget__group-discount-summary {
+  font-size: 12px;
+}
+.gosub-widget__options-container input[type="radio"] {
+  display: none;
+}
+.gosub-widget__plans-container fieldset + fieldset,
+.gosub-widget__options-container fieldset + fieldset {
+  margin-top: 10px;
+}
+.gosub-widget__plan,
+.gosub-widget__option {
+  width: 100%;
+}
+.gosub-widget__plan + .gosub-widget__plan {
+  margin-top: -1px;
+}
+.gosub-widget__option + .gosub-widget__option {
+  margin-top: 5px;
+}
+.gosub-widget__plan-header {
+  display: flex !important;
+  align-items: center;
+  padding: 2px;
+  justify-content: space-between;
+  width: 100%;
+}
+.gosub-widget__wrapper .gosub-widget__plan-pricing {
+  text-align: center;
+  flex-shrink: 0;
+}
+.gosub-widget__wrapper .gosub-pricing-off {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0;
+  padding: 0 5px;
+  background-color: #ee2c2c;
+  color: #fff;
+  line-height: 1.5;
+}
+.gosub-widget__wrapper .gosub-widget__plan label {
+  border-top: 1px solid #cccccc;
+  min-height: 60px;
+  margin-bottom: 0px;
+}
+.gosub-widget__plans-container fieldset {
+  border-left: none;
+  border-bottom: 1px solid #cccccc;
+  border-right: none;
+}
+.gosub-widget__wrapper .gosub-widget__plan label.active {
+  background-color: rgb(127 127 127 / 8%);
+}
+.gosub-widget__plan-header .gosub-widget__image {
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+}
+.gosub-widget__plan-header .gosub-widget__text {
+  flex-grow: 1;
+  text-align: start;
+}
+input:checked + .gosub-widget__plan-header .gosub-widget__unchecked-icon {
+  display: none;
+}
+input:not(:checked) + .gosub-widget__plan-header .gosub-widget__checked-icon {
+  display: none;
+}
+.gosub-cart__selling-plan-details,
+.gosub-cart-popup__selling-plan-details {
+  font-size: 12px;
+}
+.payment-change-requested {
+  display: none;
+}
+.clickyboxes.options- {
+  display: flex;
+  justify-content: space-around;
+}
+.clickyboxes.options- li {
+  display: flex;
+  padding: 0px;
+  margin: 0px;
+  width: 100%;
+  margin-right: 5px;
+}
+.has-clickyboxes .clickyboxes.options- li a {
+  font-weight: bold;
+}
+.clickyboxes.options- li a {
+  line-height: 25px;
+  border: 1px solid #939598;
+  border-radius: 5px;
+  padding: 10px 0px;
+  width: 100%;
+}
+
+.clickyboxes.options- li a.active {
+  border: 3px solid #000;
+  background: rgba(211, 211, 211, 0.1);
+}
+.gosub-widget__text.gosub-widget__price {
+  margin-bottom: 18px;
+}
+.gosub-widget__text.gosub-widget__price,
+.gosub-widget__text span {
+  cursor: pointer;
+  font-size: 18px;
+}
+.gosub-widget__wrapper__other-lang .gosub-widget__groups-container {
+  flex-direction: column;
+}
+.gosub-widget__wrapper__other-lang
+  .gosub-widget__groups-container.default-subscription-selected {
+  flex-direction: column-reverse;
+}
+@media (max-width: 384px) {
+  .has-clickyboxes .clickyboxes.options- li a {
+    font-size: 11.25px;
+  }
+}
+@media (min-width: 385px) and (max-width: 410px) {
+  .has-clickyboxes .clickyboxes.options- li a {
+    font-size: 11.5px;
+  }
+}
+
+.modal-label {
+  width: 100%;
+  display: flex;
+}
+
+.modal-radio-text {
+  flex: 1;
+  font-size: 16px;
+}
+.go-sub-status-badge-error-title {
+  color: rgb(202, 21, 21);
+}
+
+.go-sub-status-badge-error {
+  background-color: rgb(230, 230, 230);
+  padding: 4px 10px;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1em;
+}
+
+.go-sub-status-badge-error-subtitle {
+  color: rgb(107 107 107);
+  font-size: 14px;
+  line-height: 1.2;
+  margin-bottom: 6px;
+}
+
+.gosub-error-restart-button {
+  background: #333;
+  border: none;
+  border-radius: 50px;
+  color: #fff;
+  display: block;
+  font-size: 12px;
+  height: 30px;
+  width: 114px;
+  margin-bottom: 4px;
+  align-self: flex-end;
+}
+
+.gosub-error-restart-button:hover {
+  cursor: pointer;
+  transition: 0.2s;
+  opacity: 0.8;
+}
+
+.gosub-order-history-show {
+  border: none;
+  color: #6d6d6d;
+}
+
+.gosub-order-history-show:hover {
+  opacity: 0.8;
+  cursor: pointer;
+  text-decoration: underline;
+  transition: 0.2s;
+}
+
+.gosub-discount-descriptions-container div {
+  font-size: 14px;
+  margin-top: 10px;
+  padding-left: 10px;
+}
+.gosub-discount-descriptions-container div.gosub__hidden {
+  display: none;
+}
+
+.gosub-contract-top-icon svg {
+  fill: currentColor;
+}

--- a/assets/quick-add.js
+++ b/assets/quick-add.js
@@ -40,6 +40,7 @@ if (!customElements.get('quick-add-modal')) {
             this.updateImageSizes();
             this.preventVariantURLSwitching();
             super.show(opener);
+            window.GORIDE.GoSubWidget.init();
           })
           .finally(() => {
             opener.removeAttribute('aria-disabled');

--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -2,7 +2,8 @@
 {{ 'component-loading-overlay.css' | asset_url | stylesheet_tag }}
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
-
+{{ 'gosub.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'gosub-product.js' | asset_url }}" defer="defer"></script>
 
 {% if section.settings.image_shape == 'blob' %}
   {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -211,7 +211,7 @@
                 assign qty_rules = true
               endif
             -%}
-            {%- if card_product.variants.size > 1 or qty_rules -%}
+            {%- if card_product.variants.size > 1 or qty_rules or card_product.selling_plan_groups.size > 0 -%}
               <modal-opener data-modal="#QuickAdd-{{ card_product.id }}">
                 <button
                   id="{{ product_form_id }}-submit"


### PR DESCRIPTION
- `assets`フォルダに`gosub-product.js` , `gosub.css`を作成
- collecitonページにて読み込み
- quick-add.jsにて`window.GORIDE.GoSubWidget.init();`を呼ぶ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `GoSubWidget` for managing subscription-based product offerings, enhancing user interaction with product variants and pricing.
	- Added new styles in `gosub.css` for a responsive and visually appealing subscription management interface.
	- Enhanced the display logic for product modals to include selling plan options, improving user experience.

- **Bug Fixes**
	- Improved modal functionality by integrating `GoSubWidget` initialization within the `quick-add-modal`.

- **Documentation**
	- Updated references in the main product grid to include the new CSS and JavaScript files, enhancing the overall styling and interactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->